### PR TITLE
Fix occasional reorg/on_ntp_njnl_reorg subtest failure (NOSELECT error from MUPIP SIZE)

### DIFF
--- a/com/bkgrnd_reorg.csh
+++ b/com/bkgrnd_reorg.csh
@@ -1,4 +1,20 @@
 #!/usr/local/bin/tcsh -f
+#################################################################
+#								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
+#	This source code contains the intellectual property	#
+#	of its copyright holder(s), and is made available	#
+#	under a license.  If you do not know the terms of	#
+#	the license, please stop and do not read further.	#
+#								#
+#################################################################
+# This module is derived from FIS GT.M.
+#################################################################
 #
-ls
+echo "# ls -liart --full-time output follows"
+ls -liart --full-time
+echo ""
+echo "# online_reorg.csh output follows"
 $gtm_tst/com/online_reorg.csh &

--- a/com/online_reorg.csh
+++ b/com/online_reorg.csh
@@ -47,7 +47,7 @@ while (1)
 	# are called simultaneously
 	# The variable *ret* stores exit statuses after each mupip invocation so the test stops in case any sub process exits with error.
 	# This is the case for multisrv_crash test case which deliberately kills online_reorg sub processes
-	set tmpoutput = "online_reorg_$$.outx"
+	set tmpoutput = "online_reorg_$$.outx.$cnt"
 	echo "# `date` : ===== Begin round $cnt of mupip size/reorg ($tmpoutput) ====="
 	echo "# `date` : cnt = $cnt ; ff = $ff ; inff = $inff"			>>&!  $tmpoutput
 	if ($cnt % 5 == 2) then

--- a/reorg/u_inref/on_ntp_njnl_reorg.csh
+++ b/reorg/u_inref/on_ntp_njnl_reorg.csh
@@ -4,6 +4,9 @@
 # Copyright (c) 2002-2016 Fidelity National Information		#
 # Services, Inc. and/or its subsidiaries. All rights reserved.	#
 #								#
+# Copyright (c) 2018 YottaDB LLC. and/or its subsidiaries.	#
+# All rights reserved.						#
+#								#
 #	This source code contains the intellectual property	#
 #	of its copyright holder(s), and is made available	#
 #	under a license.  If you do not know the terms of	#
@@ -26,9 +29,6 @@ endif
 
 $gtm_exe/mumps $gtm_tst/com/pfill.m
 $gtm_tst/com/dbcreate.csh "mumps" 8 255 1000
-if (0 == $?test_replic) then
-	if ($?test_collation) $gtm_tst/com/enable_nct.csh
-endif
 $GTM << \aaa
 w "do ^manygbls"  do ^manygbls
 w "do in0^dbfill(""set"")"  do in0^dbfill("set")


### PR DESCRIPTION
on_ntp_njnl_reorg.csh invokes enable_nct.csh which does a set^%GBLDEF of ^a,^b, etc.
That M routines sets numeric collation for global names by a two step process. A SET ^a
first followed by a KILL ^a etc. It is possible that online_reorg.csh (a script that runs
in the background, finds ^a existing if it runs mumps -run waitforglobal just after the
SET ^a in set^%GBLDEF but before the KILL ^a. This will cause online_reorg.csh to
incorrectly assume that at least one global is guaranteed to exist in the database
and proceed with MUPIP SIZE and/or MUPIP REORG operations which could then fail with a
YDB-W-NOSELECT (and YDB-E-MUNOACTION error).

The fix is to remove the call to enable_nct.csh in reorg/u_inref/on_ntp_njnl_reorg.csh
since the global names manipulated in that script are not anyways used by this subtest.